### PR TITLE
Blueprint adds `.gitignore` on npm installation

### DIFF
--- a/packages/@ember/octane-addon-blueprint/.npmignore
+++ b/packages/@ember/octane-addon-blueprint/.npmignore
@@ -12,7 +12,6 @@
 /.env*
 /.eslintignore
 /.eslintrc.js
-/.gitignore
 /.template-lintrc.js
 /.travis.yml
 /.watchmanconfig

--- a/packages/@ember/octane-app-blueprint/.npmignore
+++ b/packages/@ember/octane-app-blueprint/.npmignore
@@ -12,7 +12,6 @@
 /.env*
 /.eslintignore
 /.eslintrc.js
-/.gitignore
 /.template-lintrc.js
 /.travis.yml
 /.watchmanconfig


### PR DESCRIPTION
@NullVoxPopuli suggested the `.npmignore` file was the #14 culprit, and I have checked that when `ember-cli` clones the repository to generate the blueprint the `.gitignore` file is not present. This PR should fix the issue, but we have to test it.



I wonder why other files included in `npmignore` are correctly auto-generated (for example the [.travis.yml](https://github.com/ember-cli/ember-octane-blueprint/blob/master/packages/%40ember/octane-addon-blueprint/.npmignore#L17) one)