### PR TITLE
Set `EMBER_VERSION` env variable to `OCTANE`

### DIFF
--- a/packages/@ember/octane-addon-blueprint/files/.ember-cli.js
+++ b/packages/@ember/octane-addon-blueprint/files/.ember-cli.js
@@ -1,6 +1,7 @@
 'use strict';
 
 process.env.EMBER_CLI_MODULE_UNIFICATION = true;
+process.env.EMBER_VERSION = "OCTANE";
 
 module.exports = {
   /**

--- a/packages/@ember/octane-app-blueprint/files/.ember-cli.js
+++ b/packages/@ember/octane-app-blueprint/files/.ember-cli.js
@@ -1,6 +1,7 @@
 'use strict';
 
 process.env.EMBER_CLI_MODULE_UNIFICATION = true;
+process.env.EMBER_VERSION = "OCTANE";
 
 module.exports = {
   /**


### PR DESCRIPTION
Required by `Update blueprints for each object type to use native JS classes` of the [Octane Tracking Issue](https://github.com/emberjs/ember.js/issues/17234)