### PR TITLE
Move `babel-transforms` to `dependencies` list

### DIFF
--- a/packages/@ember/octane-addon-blueprint/files/package.json
+++ b/packages/@ember/octane-addon-blueprint/files/package.json
@@ -21,12 +21,12 @@
     "test": "ember test"
   },
   "dependencies": {
+    "@ember-decorators/babel-transforms": "^5.1.3",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.2",
-    "@ember-decorators/babel-transforms": "^5.1.3",
     "@ember/optional-features": "^0.7.0",
     "@glimmer/component": "^0.14.0-alpha.3",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
`classProperties` could not be used in the `src` folder of the addon directory, but it could on the `tests/*`.

```
Build Error (broccoli-persistent-filter:Babel > [Babel: oct-addon1]) in oct-addon1/src/services/hola.js

oct-addon1/src/services/hola.js: Support for the experimental syntax 'classProperties' isn't currently enabled (4:8):

  2 | 
  3 | export default class HolaService extends Service {
> 4 |   val1 = 'hola - service';
    |        ^
  5 | }
  6 | 

Add @babel/plugin-proposal-class-properties (https://git.io/vb4SL) to the 'plugins' section of your Babel config to enable transformation.
```

Moving `@ember-decorators/babel-transforms` from `devDependencies` to `dependencies` solved the issue.

It was commented at https://github.com/ember-decorators/ember-decorators/issues/134#issuecomment-317098014

cc @NullVoxPopuli 

