### PR TITLE
Added `Glimmer` component example to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,35 @@ Included:
  - ember-auto-import
  - no jquery
 
+### Glimmer Component Example
+
+```src/ui/components/counter/component.js
+import Component from '@ember/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class HolaComponent extends Component {
+  @tracked count = 0;
+
+  increment() {
+    this.count++;
+  }
+
+  decrement() {
+    this.count--;
+  }
+}
+
+```
+
+```src/ui/components/counter/template.hbs
+
+Count: {{this.count}}
+<br/>
+<button {{action this.increment}}>Click to increase</button>
+<button {{action this.decrement}}>Click to decrease</button>
+
+```
+
 
 ## Building/Contributing:
 ```bash


### PR DESCRIPTION
Added an example on the Readme for the Glimmer component API.

`babel-plugin-ember-modules-api-polyfill 2.7.0` is automatically installed with the blueprint;  the Glimmer API works 🎆

Pending to bump `ember-cli-babel` when released: https://github.com/ember-cli/ember-rfc176-data/pull/113

Should the Readme of the `sparkles-component` being updated to recommend using this setup instead?

cc @rwjblue 