### PR TITLE
Unify eslint across app and addon

### DIFF
--- a/packages/@ember/octane-addon-blueprint/files/.eslintrc.js
+++ b/packages/@ember/octane-addon-blueprint/files/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
@@ -32,7 +33,7 @@ module.exports = {
       ],
       excludedFiles: [
         'src/**',
-        'tests/dummy/app/**'
+        'tests/dummy/src/**'
       ],
       parserOptions: {
         sourceType: 'script',

--- a/packages/@ember/octane-addon-blueprint/files/package.json
+++ b/packages/@ember/octane-addon-blueprint/files/package.json
@@ -47,6 +47,7 @@
     "ember-resolver": "^5.1.3",
     "ember-source": "<%= emberCanaryVersion %>",
     "eslint-plugin-ember": "^6.0.1",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.0"
   },

--- a/packages/@ember/octane-app-blueprint/files/.eslintrc.js
+++ b/packages/@ember/octane-app-blueprint/files/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.ember-cli.js',
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
@@ -29,6 +30,9 @@ module.exports = {
         'config/**/*.js',
         'lib/*/index.js'
       ],
+      excludedFiles: [
+        'src/**',
+      ],
       parserOptions: {
         sourceType: 'script',
         ecmaVersion: 2015
@@ -36,7 +40,11 @@ module.exports = {
       env: {
         browser: false,
         node: true
-      }
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+      })
     }
   ]
 };

--- a/packages/@ember/octane-app-blueprint/files/package.json
+++ b/packages/@ember/octane-app-blueprint/files/package.json
@@ -44,6 +44,7 @@
     "ember-source": "<%= emberCanaryVersion %><% if (welcome) { %>",
     "ember-welcome-page": "^3.2.0<% } %>",
     "eslint-plugin-ember": "^6.0.1",
+    "eslint-plugin-node": "^8.0.1",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.0"
   },


### PR DESCRIPTION
It's still a bit different, than classic blueprints - though I'd say I modernized them a bit. Dunno if `excludedFiles` is completely necessary.

However, if installing an addon with this patch applied `ember serve` will work again (is broken at the moment).