### PR TITLE
Update `config/targets.js` to default configuration

### DIFF
--- a/packages/@ember/octane-app-blueprint/files/config/targets.js
+++ b/packages/@ember/octane-app-blueprint/files/config/targets.js
@@ -1,8 +1,18 @@
+'use strict';
+
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions'
+];
+
+const isCI = !!process.env.CI;
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
-  browsers: [
-    'ie 11',
-    'last 1 Chrome versions',
-    'last 1 Firefox versions',
-    'last 1 Safari versions'
-  ]
+  browsers
 };


### PR DESCRIPTION
Now the blueprint will use the same `targets` configuration than the default `app` blueprint https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/config/targets.js

I found the difference when reporting https://github.com/emberjs/ember.js/issues/17678#issuecomment-468885365

cc @NullVoxPopuli 