### PR TITLE
Do not add custom types to the default resolver

### DIFF
--- a/packages/@ember/octane-app-blueprint/files/src/resolver.js
+++ b/packages/@ember/octane-app-blueprint/files/src/resolver.js
@@ -3,26 +3,15 @@ import buildResolverConfig from 'ember-resolver/ember-config';
 import config from '../config/environment';
 
 let moduleConfig = buildResolverConfig(config.modulePrefix);
+
 /*
  * If your application has custom types and collections, modify moduleConfig here
- * to add support for them.
+ * to add support for them:
+ *
+ *  moduleConfig.types = Object.assign(moduleConfig.types, {
+ *    'validator': { definitiveCollection: 'validators' },
+ *  });
  */
-
-
- moduleConfig.types = Object.assign(moduleConfig.types, {
-   // TODO: why did emberclear add this to main collection?
-   //       the existing config
-   //       https://github.com/ember-cli/ember-resolver/blob/master/mu-trees/addon/ember-config.js#L17
-   //       specifies the config 'definitiveCollection'
-  'config': { definitiveCollection: 'main' },
-  // TODO: add these to the default ember-config in ember-resolver
-  'util': { definitiveCollection: 'utils' },
-  // TODO: remove when addons can add collections and types themselves
-  //       and when sparkles-component specifies this.
-  //       OR, remove when glimmer components land
-  'component-manager': { definitiveCollection: 'main' },
- });
-
 export default Resolver.extend({
   config: moduleConfig
 });


### PR DESCRIPTION
The blueprint resolver added 3 custom types:

```
  'config': { definitiveCollection: 'main' },
  'util': { definitiveCollection: 'utils' },
  'component-manager': { definitiveCollection: 'main' },
```

- `config` and `component-manager` are already added with `buildResolverConfig`.

- `util`, we should discuss if the `util` type should be added to the resolver through `buildResolverConfig` or not.

 