### PR TITLE
Fix `app/router.js` blueprint content

### DIFF
--- a/packages/@ember/octane-addon-blueprint/package.json
+++ b/packages/@ember/octane-addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/octane-addon-blueprint",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The default blueprint for octane addons.",
   "keywords": [
     "ember-addon",

--- a/packages/@ember/octane-app-blueprint/files/app/router.js
+++ b/packages/@ember/octane-app-blueprint/files/app/router.js
@@ -1,5 +1,5 @@
 import EmberRouter from "@ember/routing/router";
-import config from "../config/environment";
+import config from "./config/environment";
 
 const Router = EmberRouter.extend({
   location: config.locationType,

--- a/packages/@ember/octane-app-blueprint/package.json
+++ b/packages/@ember/octane-app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/octane-app-blueprint",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The default blueprint for octane apps.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
After the [MU removal](https://github.com/ember-cli/ember-octane-blueprint/pull/68), apps generated with the octane app blueprint were not working. This PR fixes it by changing the content of `app/router.js` to be like the official app blueprint. 


Additionally, I have upgraded the package versions. I think when this PR get merged, the packages will automatically be upgraded.