### PR TITLE
Temporarily pinning ember-data to specific known good SHA

### DIFF
--- a/packages/@ember/octane-app-blueprint/index.js
+++ b/packages/@ember/octane-app-blueprint/index.js
@@ -22,7 +22,8 @@ module.exports = {
       let rawName = entity.name;
       let namespace = stringUtil.classify(rawName);
 
-      // temporarily pinning ember-data to specific known good SHA
+      // temporarily pinning ember-data see tracking issue for details:
+      // https://github.com/ember-cli/ember-octane-blueprint/issues/95 to
       emberDataURL = 'github:emberjs/data#1df833396855d956b817540923dd89338463fec2';
 
       return {

--- a/packages/@ember/octane-app-blueprint/index.js
+++ b/packages/@ember/octane-app-blueprint/index.js
@@ -22,6 +22,9 @@ module.exports = {
       let rawName = entity.name;
       let namespace = stringUtil.classify(rawName);
 
+      // temporarily pinning ember-data to specific known good SHA
+      emberDataURL = 'github:emberjs/data#1df833396855d956b817540923dd89338463fec2';
+
       return {
         name,
         modulePrefix: name,


### PR DESCRIPTION
Fixes #93 

@NullVoxPopuli there wasn't any need to update the add blueprint, as it doesn't include `ember-data`.