### PR TITLE
Fix mistake in rate limiting error handler.

### DIFF
--- a/packages/octane-blueprint-utils/index.js
+++ b/packages/octane-blueprint-utils/index.js
@@ -55,7 +55,7 @@ function getRepoVersion(org, repo) {
         return getRepoVersionFromTarball(org, repo);
       }
 
-      throw error;
+      throw result;
     })
   .then(version => `github:${org}/${repo}#${version}`);
 }


### PR DESCRIPTION
Fixes the specific error reported in https://github.com/ember-cli/ember-octane-blueprint/issues/96 (reference error when the `got` request fails), but that error is masking some other issue that will need to be tracked down once this lands and is released.