### PR TITLE
pin ember data version to ^3.10.0

### DIFF
--- a/packages/@ember/octane-app-blueprint/files/package.json
+++ b/packages/@ember/octane-app-blueprint/files/package.json
@@ -34,7 +34,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-uglify": "^2.1.0",
-    "ember-data": "<%= emberData %>",
+    "ember-data": "^3.10.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/packages/@ember/octane-app-blueprint/index.js
+++ b/packages/@ember/octane-app-blueprint/index.js
@@ -14,17 +14,13 @@ module.exports = {
   locals(options) {
     return Promise.all([
       getRepoVersion('ember-cli', 'ember-cli'),
-      getRepoVersion('emberjs', 'data'),
       getURLFor('canary')
-    ]).then(([emberCLIURL, emberDataURL, emberURL]) => {
+    ]).then(([emberCLIURL, emberURL]) => {
       let name = stringUtil.dasherize(options.entity.name);
       let entity = options.entity;
       let rawName = entity.name;
       let namespace = stringUtil.classify(rawName);
 
-      // temporarily pinning ember-data see tracking issue for details:
-      // https://github.com/ember-cli/ember-octane-blueprint/issues/95 to
-      emberDataURL = 'github:emberjs/data#1df833396855d956b817540923dd89338463fec2';
 
       return {
         name,
@@ -33,7 +29,6 @@ module.exports = {
         yarn: options.yarn,
         welcome: options.welcome,
         emberCanaryVersion: emberURL,
-        emberData: emberDataURL,
         emberCLI: emberCLIURL
       };
     });


### PR DESCRIPTION
This PR address an issue (reported [here](https://github.com/ember-cli/ember-octane-blueprint/issues/95)) with Ember Data in the current Octane blueprint where there were some issues because the default usage of `fetch` in ember data was still in progress.

This work has now been completed [here](https://github.com/emberjs/data/pull/5900), so we can pin the ember data version to the latest stable release :muscle: