### PR TITLE
Use export default class Router extends EmberRouter {}.

### DIFF
--- a/packages/@ember/octane-addon-blueprint/files/tests/dummy/app/router.js
+++ b/packages/@ember/octane-addon-blueprint/files/tests/dummy/app/router.js
@@ -1,12 +1,10 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-class Router extends EmberRouter {
+export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 }
 
 Router.map(function() {
 });
-
-export default Router;

--- a/packages/@ember/octane-app-blueprint/files/app/router.js
+++ b/packages/@ember/octane-app-blueprint/files/app/router.js
@@ -1,12 +1,10 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-class Router extends EmberRouter {
+export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 }
 
 Router.map(function() {
 });
-
-export default Router;


### PR DESCRIPTION
Because, why not!?