### PR TITLE
Use git SHA for ember-cli-htmlbars

### DIFF
--- a/packages/@ember/octane-addon-blueprint/files/package.json
+++ b/packages/@ember/octane-addon-blueprint/files/package.json
@@ -35,7 +35,7 @@
     "ember-cli": "<%= emberCLI %>",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",
-    "ember-cli-htmlbars": "ember-cli/ember-cli-htmlbars#colocation",
+    "ember-cli-htmlbars": "<%= emberCLIHTMLBars %>",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/packages/@ember/octane-addon-blueprint/index.js
+++ b/packages/@ember/octane-addon-blueprint/index.js
@@ -13,8 +13,9 @@ module.exports = {
   locals(options) {
     return Promise.all([
       getRepoVersion('ember-cli', 'ember-cli'),
+      getRepoVersion('ember-cli', 'ember-cli-htmlbars', 'colocation'),
       getURLFor('canary')
-    ]).then(([emberCLIURL, emberURL]) => {
+    ]).then(([emberCLI, emberCLIHTMLBars, emberURL]) => {
       let entity = { name: 'dummy' };
       let rawName = entity.name;
       let name = stringUtil.dasherize(rawName);
@@ -32,7 +33,8 @@ module.exports = {
         addonName,
         addonNamespace,
         emberCanaryVersion: emberURL,
-        emberCLI: emberCLIURL,
+        emberCLI,
+        emberCLIHTMLBars,
         year: new Date().getFullYear(),
         yarn: options.yarn,
         welcome: options.welcome,

--- a/packages/@ember/octane-app-blueprint/files/package.json
+++ b/packages/@ember/octane-app-blueprint/files/package.json
@@ -27,7 +27,7 @@
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.8.0",
     "ember-cli-dependency-checker": "^3.1.0",
-    "ember-cli-htmlbars": "ember-cli/ember-cli-htmlbars#colocation",
+    "ember-cli-htmlbars": "<%= emberCLIHTMLBars %>",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/packages/@ember/octane-app-blueprint/index.js
+++ b/packages/@ember/octane-app-blueprint/index.js
@@ -14,8 +14,9 @@ module.exports = {
   locals(options) {
     return Promise.all([
       getRepoVersion('ember-cli', 'ember-cli'),
+      getRepoVersion('ember-cli', 'ember-cli-htmlbars', 'colocation'),
       getURLFor('canary')
-    ]).then(([emberCLIURL, emberURL]) => {
+    ]).then(([emberCLI, emberCLIHTMLBars, emberURL]) => {
       let name = stringUtil.dasherize(options.entity.name);
       let entity = options.entity;
       let rawName = entity.name;
@@ -29,7 +30,8 @@ module.exports = {
         yarn: options.yarn,
         welcome: options.welcome,
         emberCanaryVersion: emberURL,
-        emberCLI: emberCLIURL
+        emberCLI,
+        emberCLIHTMLBars,
       };
     });
 

--- a/packages/octane-blueprint-utils/index.js
+++ b/packages/octane-blueprint-utils/index.js
@@ -2,7 +2,7 @@
 
 const got = require('got');
 
-function getRepoVersionFromTarball(org, repo) {
+function getRepoVersionFromTarball(org, repo, branch = 'master') {
   // lazy to avoid extra work when not rate-limited
   const tar = require('tar-stream');
   const zlib = require('zlib');
@@ -26,7 +26,7 @@ function getRepoVersionFromTarball(org, repo) {
     });
 
     got
-      .stream(`http://github.com/${org}/${repo}/tarball/master`)
+      .stream(`http://github.com/${org}/${repo}/tarball/${branch}`)
       .pipe(zlib.createGunzip())
       .pipe(extract)
       .on('error', (reason) => {
@@ -42,9 +42,9 @@ function getRepoVersionFromTarball(org, repo) {
   });
 }
 
-function getRepoVersion(org, repo) {
+function getRepoVersion(org, repo, branch = 'master') {
   return got(
-    `https://api.github.com/repos/${org}/${repo}/git/refs/heads/master`,
+    `https://api.github.com/repos/${org}/${repo}/git/refs/heads/${branch}`,
     { json: true },
   )
     .then(result => {
@@ -52,7 +52,7 @@ function getRepoVersion(org, repo) {
     })
     .catch(result => {
       if (result.statusCode === 403 && result.headers['x-ratelimit-remaining'] === '0') {
-        return getRepoVersionFromTarball(org, repo);
+        return getRepoVersionFromTarball(org, repo, branch);
       }
 
       throw result;


### PR DESCRIPTION
Using a branch was causing problem for people who had previously ran `yarn install` when the branch was broken, since yarn caches the commit locally indefinitely.

Also renamed the variables since they are not actually URLs.