### PR TITLE
Fix `ember-cli-htmlbars` issue

### DIFF
--- a/packages/@ember/octane-addon-blueprint/package.json
+++ b/packages/@ember/octane-addon-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/octane-addon-blueprint",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "The default blueprint for octane addons.",
   "keywords": [
     "ember-addon",
@@ -15,7 +15,7 @@
   "dependencies": {
     "ember-cli-string-utils": "^1.1.0",
     "ember-source-channel-url": "^2.0.1",
-    "octane-blueprint-utils": "^0.2.3"
+    "octane-blueprint-utils": "^0.3.0"
   },
   "engines": {
     "node": "8.* || >= 10.*"

--- a/packages/@ember/octane-app-blueprint/package.json
+++ b/packages/@ember/octane-app-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/octane-app-blueprint",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "The default blueprint for octane apps.",
   "keywords": [
     "ember-addon",
@@ -15,7 +15,7 @@
   "dependencies": {
     "ember-cli-string-utils": "^1.1.0",
     "ember-source-channel-url": "^2.0.1",
-    "octane-blueprint-utils": "^0.2.3"
+    "octane-blueprint-utils": "^0.3.0"
   },
   "devDependencies": {
     "eslint": "^6.2.2",

--- a/packages/octane-blueprint-utils/package.json
+++ b/packages/octane-blueprint-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octane-blueprint-utils",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "license": "MIT",
   "author": "ember-cli contributors",
   "repository": "https://github.com/ember-cli/ember-octane-blueprint",


### PR DESCRIPTION
Blueprints v0.32.0 has a bug that caused the following errors in components:

```
Failed to create an instance of 'component:foo'. Most likely an improperly defined class or an invalid module export.
```

This was caused by using an incompatible version of `ember-cli-htmlbars` (currently, the `colocation` branch is required). The root cause was that the version of `octane-blueprint-utils` was not released with the blueprints, so the old verions of `getRepoVersion` was used. It had a "compatible" function signature so no errors were raised, but instead, the third positional argument, which corresponds to the Git `branch`, was completely ignored, causing the blueprint to install from the `master` branch of `ember-cli-htmlbars` unexpectedly.