### PR TITLE
Remove @ember/render-modifiers from addon blueprint.

### DIFF
--- a/packages/@ember/octane-addon-blueprint/files/package.json
+++ b/packages/@ember/octane-addon-blueprint/files/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
-    "@ember/render-modifiers": "^1.0.0",
     "@glimmer/component": "^0.14.0-alpha.12",
     "babel-eslint": "^8.0.2",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
These modifiers are _specifically_ intended to install when they are needed, not eagerly in all apps/addons.

https://github.com/emberjs/rfcs/blob/master/text/0415-render-element-modifiers.md#official-addon