### PR TITLE
Use latest ember-source beta tarball.

### DIFF
--- a/packages/@ember/octane-addon-blueprint/index.js
+++ b/packages/@ember/octane-addon-blueprint/index.js
@@ -3,6 +3,7 @@
 const latestVersion = require('latest-version');
 const stringUtil = require('ember-cli-string-utils');
 const getRepoVersion = require('octane-blueprint-utils').getRepoVersion;
+const getChannelURL = require('ember-source-channel-url');
 
 module.exports = {
   description: 'Generates an Ember Octane addon.',
@@ -14,7 +15,7 @@ module.exports = {
     return Promise.all([
       latestVersion('ember-cli', {version: 'beta'}),
       getRepoVersion('ember-cli', 'ember-cli-htmlbars', 'colocation'),
-      latestVersion('ember-source', {version: 'beta'})
+      getChannelURL('beta')
     ]).then(([emberCLI, emberCLIHTMLBars, emberSource]) => {
       let entity = { name: 'dummy' };
       let rawName = entity.name;

--- a/packages/@ember/octane-app-blueprint/index.js
+++ b/packages/@ember/octane-app-blueprint/index.js
@@ -3,6 +3,7 @@
 const latestVersion = require('latest-version');
 const stringUtil = require('ember-cli-string-utils');
 const getRepoVersion = require('octane-blueprint-utils').getRepoVersion;
+const getChannelURL = require('ember-source-channel-url');
 
 module.exports = {
   description: 'Generates an Ember Octane application.',
@@ -15,7 +16,7 @@ module.exports = {
       latestVersion('ember-cli', {version: 'beta'}),
       getRepoVersion('ember-cli', 'ember-cli-htmlbars', 'colocation'),
       latestVersion('ember-data', {version: 'beta'}),
-      latestVersion('ember-source', {version: 'beta'})
+      getChannelURL('beta')
     ]).then(([emberCLI, emberCLIHTMLBars, emberData, emberSource]) => {
       let name = stringUtil.dasherize(options.entity.name);
       let entity = options.entity;


### PR DESCRIPTION
This is needed because we want to rely on usage of `@ember/edition-utils`, but that isn't in a published to npm just yet.