### PR TITLE
Fix: generated assets get out of sync with index.html when app name (package.json#name) changes

### DIFF
--- a/packages/@ember/octane-app-blueprint/files/app/index.html
+++ b/packages/@ember/octane-app-blueprint/files/app/index.html
@@ -10,7 +10,7 @@
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/<%= name %>.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/{{MODULE_PREFIX}}.css">
 
     {{content-for "head-footer"}}
   </head>
@@ -18,7 +18,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/<%= name %>.js"></script>
+    <script src="{{rootURL}}assets/{{MODULE_PREFIX}}.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/packages/@ember/octane-app-blueprint/files/app/index.html
+++ b/packages/@ember/octane-app-blueprint/files/app/index.html
@@ -10,7 +10,7 @@
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/{{MODULE_PREFIX}}.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/{{asset-name}}.css">
 
     {{content-for "head-footer"}}
   </head>
@@ -18,7 +18,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/{{MODULE_PREFIX}}.js"></script>
+    <script src="{{rootURL}}assets/{{asset-name}}.js"></script>
 
     {{content-for "body-footer"}}
   </body>


### PR DESCRIPTION
requires: https://github.com/ember-cli/ember-cli/pull/8845


This should fix issues I first encountered on codesandbox where renaming the sandbox changes your package.json name, which changes MODULE_PREFIX. 

Note: this is different from config/environment.js#modulePrefix, where that just affects your import paths (this'd also be more annoying to change for users as it'd require them to update all their imports, so it's a good thing the package.json#name / dist/assets/name.{css,js} are separated from the modulePrefix in environment.js)

To replicate locally:
```
ember new my-app
# build project, notice dist/assets has:
# - my-app.css, my-app.js

change package.json#name to "my-app-updated"
# build project, notice dist/assets has:
# - my-app-updated.css, my-app-updated.js
```
but the output index.html still expects my-app instead of my-app-updated
