### PR TITLE
Remove EMBER_METAL_PROPERTIES from config

### DIFF
--- a/packages/@ember/octane-app-blueprint/files/config/environment.js
+++ b/packages/@ember/octane-app-blueprint/files/config/environment.js
@@ -10,7 +10,6 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_MODULE_UNIFICATION: true
-        EMBER_METAL_TRACKED_PROPERTIES: true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.


### PR DESCRIPTION
With Ember v3.13.x this property is no longer required to be set to `true`

cc: @pzuraq